### PR TITLE
Prepare v2.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,33 +4,21 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      matrix:
-        os: [windows-latest, ubuntu-latest]
-        include:
-        - os: ubuntu-latest
-          DOTNET_ARGS: --configuration Release --framework netcoreapp3.1
-
-        - os: windows-latest
-          DOTNET_ARGS: --configuration Release
+    runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v2
 
     - name: Build
-      run: dotnet build ${{ matrix.DOTNET_ARGS }} Akka.Monitoring.Datadog.sln
+      run: dotnet build --configuration Release Akka.Monitoring.Datadog.sln
     
     - name: Run tests
-      run: dotnet test ${{ matrix.DOTNET_ARGS }}
+      run: dotnet test --configuration Release
     
     - name: Create package
-      run: dotnet pack ${{ matrix.DOTNET_ARGS }} ./src/Akka.Monitoring.Datadog/Akka.Monitoring.Datadog.csproj
-      if: ${{ matrix.os == 'windows-latest' }}
+      run: dotnet pack --configuration Release ./src/Akka.Monitoring.Datadog/Akka.Monitoring.Datadog.csproj
     
     - name: Upload artifact
       uses: actions/upload-artifact@v2.1.4
-      if: ${{ matrix.os == 'windows-latest' }}
       with:
         path: ./src/Akka.Monitoring.Datadog/bin/Release/*.nupkg

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,21 +4,33 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+        include:
+        - os: ubuntu-latest
+          DOTNET_ARGS: --configuration Release --framework netcoreapp3.1
+
+        - os: windows-latest
+          DOTNET_ARGS: --configuration Release
 
     steps:
     - uses: actions/checkout@v2
 
     - name: Build
-      run: dotnet build --configuration Release Akka.Monitoring.Datadog.sln
+      run: dotnet build ${{ matrix.DOTNET_ARGS }} Akka.Monitoring.Datadog.sln
     
     - name: Run tests
-      run: dotnet test
+      run: dotnet test ${{ matrix.DOTNET_ARGS }}
     
     - name: Create package
-      run: dotnet pack --configuration Release ./src/Akka.Monitoring.Datadog/Akka.Monitoring.Datadog.csproj
+      run: dotnet pack ${{ matrix.DOTNET_ARGS }} ./src/Akka.Monitoring.Datadog/Akka.Monitoring.Datadog.csproj
+      if: ${{ matrix.os == 'windows-latest' }}
     
     - name: Upload artifact
       uses: actions/upload-artifact@v2.1.4
+      if: ${{ matrix.os == 'windows-latest' }}
       with:
         path: ./src/Akka.Monitoring.Datadog/bin/Release/*.nupkg

--- a/samples/Akka.Monitoring.Datadog.Demo/Akka.Monitoring.Datadog.Demo.csproj
+++ b/samples/Akka.Monitoring.Datadog.Demo/Akka.Monitoring.Datadog.Demo.csproj
@@ -21,8 +21,8 @@
     <ProjectReference Include="..\..\src\Akka.Monitoring.Datadog\Akka.Monitoring.Datadog.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Akka" Version="1.3.12" />
-    <PackageReference Include="Akka.Monitoring" Version="0.7.0" NoWarn="NU1701" />
+    <PackageReference Include="Akka" Version="1.4.10" />
+    <PackageReference Include="Akka.Monitoring" Version="1.1.0" />
     <PackageReference Include="DogStatsD-CSharp-Client" Version="5.0.2" />
   </ItemGroup>
 </Project>

--- a/samples/Akka.Monitoring.Datadog.Demo/Akka.Monitoring.Datadog.Demo.csproj
+++ b/samples/Akka.Monitoring.Datadog.Demo/Akka.Monitoring.Datadog.Demo.csproj
@@ -1,12 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFrameworks>net48;netcoreapp3.1</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <AssemblyTitle>Akka.Monitoring.Datadog.Demo</AssemblyTitle>
     <Product>Akka.Monitoring.Datadog.Demo</Product>
     <Copyright>Copyright ©  2017</Copyright>
-    <OutputPath>bin\$(Configuration)\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugType>full</DebugType>
@@ -14,8 +13,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System.Data.DataSetExtensions" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Net.Http" />
   </ItemGroup>
@@ -24,7 +22,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Akka" Version="1.3.12" />
-    <PackageReference Include="Akka.Monitoring" Version="0.7.0" />
+    <PackageReference Include="Akka.Monitoring" Version="0.7.0" NoWarn="NU1701" />
     <PackageReference Include="DogStatsD-CSharp-Client" Version="5.0.2" />
   </ItemGroup>
 </Project>

--- a/samples/Akka.Monitoring.Datadog.Demo/Akka.Monitoring.Datadog.Demo.csproj
+++ b/samples/Akka.Monitoring.Datadog.Demo/Akka.Monitoring.Datadog.Demo.csproj
@@ -5,7 +5,7 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <AssemblyTitle>Akka.Monitoring.Datadog.Demo</AssemblyTitle>
     <Product>Akka.Monitoring.Datadog.Demo</Product>
-    <Copyright>Copyright ©  2017</Copyright>
+    <Copyright>2020 Greg Shackles</Copyright>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugType>full</DebugType>

--- a/src/Akka.Monitoring.Datadog/Akka.Monitoring.Datadog.csproj
+++ b/src/Akka.Monitoring.Datadog/Akka.Monitoring.Datadog.csproj
@@ -3,14 +3,14 @@
     <TargetFrameworks>net48;netcoreapp3.1</TargetFrameworks>
     <AssemblyTitle>Akka.Monitoring.Datadog</AssemblyTitle>
     <Description>Akka.Monitoring extension for reporting to Datadog</Description>
-    <Copyright>Copyright 2020 Greg Shackles</Copyright>
-    <Version>1.0.0.0</Version>
+    <Copyright>2020 Greg Shackles</Copyright>
+    <Version>1.1.0.0-alpha</Version>
     <ConsolePause>false</ConsolePause>
     <Authors>gshackles</Authors>
     <PackageId>Akka.Monitoring.Datadog</PackageId>
     <PackageLicenseUrl>https://github.com/gshackles/Akka.Monitoring.Datadog/blob/main/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/gshackles/Akka.Monitoring.Datadog</PackageProjectUrl>
-    <PackageReleaseNotes>Initial release</PackageReleaseNotes>
+    <PackageReleaseNotes>Add .NET Core 3.1 support</PackageReleaseNotes>
     <PackageTags>akka actors actor model Akka concurrency monitoring statsd datadog</PackageTags>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/Akka.Monitoring.Datadog/Akka.Monitoring.Datadog.csproj
+++ b/src/Akka.Monitoring.Datadog/Akka.Monitoring.Datadog.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard20</TargetFrameworks>
     <AssemblyTitle>Akka.Monitoring.Datadog</AssemblyTitle>
     <Description>Akka.Monitoring extension for reporting to Datadog</Description>
     <Copyright>2020 Greg Shackles</Copyright>
@@ -17,8 +17,8 @@
     <DebugType>full</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Akka" Version="[1.3.12, 2.0)" />
-    <PackageReference Include="Akka.Monitoring" Version="[0.7.0, 1.0)" NoWarn="NU1701" />
+    <PackageReference Include="Akka" Version="[1.4.10, 2.0)" />
+    <PackageReference Include="Akka.Monitoring" Version="[1.1.0, 2.0)" />
     <PackageReference Include="DogStatsD-CSharp-Client" Version="[5.0.2, 6.0)" />
   </ItemGroup>
 </Project>

--- a/src/Akka.Monitoring.Datadog/Akka.Monitoring.Datadog.csproj
+++ b/src/Akka.Monitoring.Datadog/Akka.Monitoring.Datadog.csproj
@@ -4,13 +4,13 @@
     <AssemblyTitle>Akka.Monitoring.Datadog</AssemblyTitle>
     <Description>Akka.Monitoring extension for reporting to Datadog</Description>
     <Copyright>2020 Greg Shackles</Copyright>
-    <Version>1.1.0.0-alpha</Version>
+    <Version>2.0.0.0</Version>
     <ConsolePause>false</ConsolePause>
     <Authors>gshackles</Authors>
     <PackageId>Akka.Monitoring.Datadog</PackageId>
     <PackageLicenseUrl>https://github.com/gshackles/Akka.Monitoring.Datadog/blob/main/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/gshackles/Akka.Monitoring.Datadog</PackageProjectUrl>
-    <PackageReleaseNotes>Add .NET Core 3.1 support</PackageReleaseNotes>
+    <PackageReleaseNotes>Target .NET Standard 2.0</PackageReleaseNotes>
     <PackageTags>akka actors actor model Akka concurrency monitoring statsd datadog</PackageTags>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/Akka.Monitoring.Datadog/Akka.Monitoring.Datadog.csproj
+++ b/src/Akka.Monitoring.Datadog/Akka.Monitoring.Datadog.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFrameworks>net48;netcoreapp3.1</TargetFrameworks>
     <AssemblyTitle>Akka.Monitoring.Datadog</AssemblyTitle>
     <Description>Akka.Monitoring extension for reporting to Datadog</Description>
     <Copyright>Copyright 2020 Greg Shackles</Copyright>
@@ -15,15 +15,10 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugType>full</DebugType>
-    <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <OutputPath>bin\Release</OutputPath>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Akka" Version="[1.3.12, 2.0)" />
-    <PackageReference Include="Akka.Monitoring" Version="[0.7.0, 1.0)" />
+    <PackageReference Include="Akka.Monitoring" Version="[0.7.0, 1.0)" NoWarn="NU1701" />
     <PackageReference Include="DogStatsD-CSharp-Client" Version="[5.0.2, 6.0)" />
   </ItemGroup>
 </Project>

--- a/tests/Akka.Monitoring.Datadog.Tests/Akka.Monitoring.Datadog.Tests.csproj
+++ b/tests/Akka.Monitoring.Datadog.Tests/Akka.Monitoring.Datadog.Tests.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net48;netcoreapp3.1</TargetFrameworks>
     <AssemblyTitle>Akka.Monitoring.Datadog.Tests</AssemblyTitle>
     <Description>Akka.Monitoring monitor tests for Datadog</Description>
-    <Copyright>2017 Greg Shackles</Copyright>
+    <Copyright>2020 Greg Shackles</Copyright>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugType>full</DebugType>

--- a/tests/Akka.Monitoring.Datadog.Tests/Akka.Monitoring.Datadog.Tests.csproj
+++ b/tests/Akka.Monitoring.Datadog.Tests/Akka.Monitoring.Datadog.Tests.csproj
@@ -19,8 +19,8 @@
     <ProjectReference Include="..\..\src\Akka.Monitoring.Datadog\Akka.Monitoring.Datadog.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Akka" Version="1.3.12" />
-    <PackageReference Include="Akka.Monitoring" Version="0.7.0" NoWarn="NU1701" />
+    <PackageReference Include="Akka" Version="1.4.10" />
+    <PackageReference Include="Akka.Monitoring" Version="1.1.0" />
     <PackageReference Include="DogStatsD-CSharp-Client" Version="5.0.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />

--- a/tests/Akka.Monitoring.Datadog.Tests/Akka.Monitoring.Datadog.Tests.csproj
+++ b/tests/Akka.Monitoring.Datadog.Tests/Akka.Monitoring.Datadog.Tests.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFrameworks>net48;netcoreapp3.1</TargetFrameworks>
     <AssemblyTitle>Akka.Monitoring.Datadog.Tests</AssemblyTitle>
     <Description>Akka.Monitoring monitor tests for Datadog</Description>
     <Copyright>2017 Greg Shackles</Copyright>
-    <OutputPath>bin\$(Configuration)\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugType>full</DebugType>
@@ -12,8 +11,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System.Data.DataSetExtensions" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Net.Http" />
   </ItemGroup>
@@ -22,14 +20,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Akka" Version="1.3.12" />
-    <PackageReference Include="Akka.Monitoring" Version="0.7.0" />
+    <PackageReference Include="Akka.Monitoring" Version="0.7.0" NoWarn="NU1701" />
     <PackageReference Include="DogStatsD-CSharp-Client" Version="5.0.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.console" Version="2.2.0">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
~Tracking the changes targeted for v1.1, which is effectively just adding a .NET Core 3.1 target plus some little cleanups.~

Targeting .NET Standard 2.0 instead now that it's supported, and bumping this library to 2.0 accordingly